### PR TITLE
Enhance News Website Design

### DIFF
--- a/may-2025/joyful-sunshine/news-website/index.html
+++ b/may-2025/joyful-sunshine/news-website/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Stay updated with the latest news from Joyful Sunshine News">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&family=Roboto+Slab:wght@700;900&display=swap" rel="stylesheet">
 </head>
 <body>
     <header>

--- a/may-2025/joyful-sunshine/news-website/styles.css
+++ b/may-2025/joyful-sunshine/news-website/styles.css
@@ -1,27 +1,55 @@
+/* Enhanced News Website Styles - Premium Look (CNN, BBC, Geektime inspired) */
+:root {
+    --primary-bg: #f5f6fa;
+    --primary-color: #222;
+    --accent: #c00;
+    --accent-dark: #900;
+    --header-bg: #fff;
+    --header-shadow: 0 2px 8px rgba(0,0,0,0.06);
+    --nav-link: #222;
+    --nav-link-active: var(--accent);
+    --nav-link-hover: var(--accent-dark);
+    --article-bg: #fff;
+    --article-shadow: 0 2px 12px rgba(0,0,0,0.07);
+    --footer-bg: #fff;
+    --footer-color: #888;
+    --meta-color: #888;
+    --border-radius: 10px;
+    --transition: 0.25s cubic-bezier(.4,0,.2,1);
+    --font-main: 'Roboto', Arial, sans-serif;
+    --font-headline: 'Roboto Slab', 'Roboto', Arial, sans-serif;
+}
+
 body {
-    font-family: Arial, sans-serif;
+    font-family: var(--font-main);
     margin: 0;
     padding: 0;
-    background: #f9fafb;
-    color: #222;
-    transition: background-color 0.3s, color 0.3s;
+    background: var(--primary-bg);
+    color: var(--primary-color);
+    line-height: 1.7;
+    font-size: 1.08rem;
+    transition: background-color var(--transition), color var(--transition);
 }
 
 header {
-    background: #ffeb3b;
-    padding: 1.5rem 0 1rem 0;
+    background: var(--header-bg);
+    box-shadow: var(--header-shadow);
+    padding: 2rem 0 1.2rem 0;
     text-align: center;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.04);
     position: relative;
-    transition: background-color 0.3s;
+    border-bottom: 2px solid #ececec;
+    z-index: 10;
 }
 
 header h1 {
     margin: 0 0 0.5rem 0;
-    font-size: 2.5rem;
-    color: #f57c00;
-    letter-spacing: 2px;
-    transition: color 0.3s;
+    font-size: 2.8rem;
+    font-family: var(--font-headline);
+    color: var(--accent);
+    letter-spacing: 1.5px;
+    font-weight: 900;
+    text-shadow: 0 2px 8px rgba(200,0,0,0.04);
+    transition: color var(--transition);
 }
 
 nav ul {
@@ -30,96 +58,111 @@ nav ul {
     margin: 0;
     display: flex;
     justify-content: center;
-    gap: 2rem;
+    gap: 2.5rem;
+    font-size: 1.1rem;
+    font-weight: 700;
 }
 
 nav a {
     text-decoration: none;
-    color: #333;
-    font-weight: bold;
-    transition: color 0.2s;
+    color: var(--nav-link);
     position: relative;
-    padding-bottom: 5px;
+    padding-bottom: 6px;
+    transition: color var(--transition);
 }
 
+nav a.active,
 nav a:hover {
-    color: #f57c00;
+    color: var(--nav-link-active);
 }
 
-nav a.active {
-    color: #f57c00;
-}
-
-nav a.active::after {
+nav a.active::after,
+nav a:hover::after {
     content: '';
     position: absolute;
-    bottom: 0;
     left: 0;
+    bottom: 0;
     width: 100%;
-    height: 2px;
-    background-color: #f57c00;
-    transform: scaleX(1);
-    transition: transform 0.3s;
+    height: 3px;
+    background: var(--accent);
+    border-radius: 2px;
+    transition: background var(--transition);
 }
 
 nav a::after {
     content: '';
     position: absolute;
-    bottom: 0;
     left: 0;
+    bottom: 0;
     width: 100%;
-    height: 2px;
-    background-color: #f57c00;
-    transform: scaleX(0);
-    transition: transform 0.3s;
-}
-
-nav a:hover::after {
-    transform: scaleX(1);
+    height: 3px;
+    background: transparent;
+    border-radius: 2px;
+    transition: background var(--transition);
 }
 
 main {
-    max-width: 800px;
-    margin: 2rem auto;
-    padding: 0 1rem;
-    transition: opacity 0.3s;
+    max-width: 900px;
+    margin: 2.5rem auto 2rem auto;
+    padding: 0 1.5rem;
+    transition: opacity var(--transition);
 }
 
 article {
-    background: #fff;
-    border-radius: 8px;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.06);
-    padding: 1.5rem;
-    margin-bottom: 2rem;
-    transition: all 0.3s ease;
+    background: var(--article-bg);
+    border-radius: var(--border-radius);
+    box-shadow: var(--article-shadow);
+    padding: 2rem 2rem 1.5rem 2rem;
+    margin-bottom: 2.2rem;
+    transition: box-shadow var(--transition), transform var(--transition);
     cursor: pointer;
+    border-left: 6px solid var(--accent);
 }
 
 article h2, article h3 {
     margin-top: 0;
-    color: #f57c00;
-    transition: color 0.3s;
+    font-family: var(--font-headline);
+    color: var(--accent);
+    font-weight: 800;
+    letter-spacing: 0.5px;
+    transition: color var(--transition);
+}
+
+article h2 {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+article h3 {
+    font-size: 1.3rem;
+    margin-bottom: 0.3rem;
 }
 
 .meta {
-    font-size: 0.9rem;
-    color: #888;
-    margin-bottom: 0.5rem;
-    transition: color 0.3s;
+    font-size: 0.95rem;
+    color: var(--meta-color);
+    margin-bottom: 0.7rem;
+    font-style: italic;
+    letter-spacing: 0.2px;
+    transition: color var(--transition);
 }
 
 .news-list article {
     margin-bottom: 1.5rem;
+    border-left: 4px solid #ececec;
+    box-shadow: none;
+    padding: 1.2rem 1.5rem 1rem 1.5rem;
 }
 
 footer {
-    background: #ffeb3b;
+    background: var(--footer-bg);
     text-align: center;
-    padding: 1rem 0;
-    color: #333;
-    font-size: 1rem;
-    box-shadow: 0 -2px 4px rgba(0,0,0,0.04);
-    transition: background-color 0.3s, color 0.3s;
+    padding: 1.2rem 0 2.5rem 0;
+    color: var(--footer-color);
+    font-size: 1.05rem;
+    border-top: 2px solid #ececec;
+    box-shadow: 0 -2px 8px rgba(0,0,0,0.03);
+    transition: background-color var(--transition), color var(--transition);
 }
 
 /* Animation classes */
@@ -133,51 +176,55 @@ footer {
 
 /* Article hover and expanded states */
 .article-hover {
-    transform: translateY(-5px);
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    transform: translateY(-6px) scale(1.01);
+    box-shadow: 0 8px 32px rgba(200,0,0,0.10);
+    border-left: 8px solid var(--accent-dark);
 }
 
 .article-expanded {
-    transform: scale(1.02);
-    box-shadow: 0 8px 24px rgba(0,0,0,0.12);
+    transform: scale(1.025);
+    box-shadow: 0 12px 36px rgba(200,0,0,0.13);
+    border-left: 10px solid var(--accent);
 }
 
 /* Dark theme */
 .dark-theme {
-    background: #121212;
+    background: #181a1b;
     color: #e0e0e0;
 }
 
 .dark-theme header {
-    background: #2c2c2c;
+    background: #232526;
+    border-bottom: 2px solid #232526;
 }
 
 .dark-theme header h1 {
-    color: #ffab40;
+    color: #ff5252;
 }
 
 .dark-theme nav a {
     color: #e0e0e0;
 }
 
-.dark-theme nav a:hover,
-.dark-theme nav a.active {
-    color: #ffab40;
+.dark-theme nav a.active,
+.dark-theme nav a:hover {
+    color: #ff5252;
 }
 
-.dark-theme nav a::after,
-.dark-theme nav a.active::after {
-    background-color: #ffab40;
+.dark-theme nav a.active::after,
+.dark-theme nav a:hover::after {
+    background: #ff5252;
 }
 
 .dark-theme article {
-    background: #1e1e1e;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+    background: #232526;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.18);
+    border-left: 6px solid #ff5252;
 }
 
 .dark-theme article h2,
 .dark-theme article h3 {
-    color: #ffab40;
+    color: #ff5252;
 }
 
 .dark-theme .meta {
@@ -185,30 +232,39 @@ footer {
 }
 
 .dark-theme footer {
-    background: #2c2c2c;
+    background: #232526;
     color: #e0e0e0;
+    border-top: 2px solid #232526;
 }
 
 /* Theme toggle button */
 .theme-toggle {
     position: absolute;
-    top: 1rem;
-    right: 1rem;
-    background: none;
-    border: none;
+    top: 1.2rem;
+    right: 1.2rem;
+    background: #fff;
+    border: 1px solid #ececec;
     font-size: 1.5rem;
     cursor: pointer;
     padding: 0.5rem;
     border-radius: 50%;
-    transition: background-color 0.3s;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+    transition: background-color var(--transition), border var(--transition);
 }
 
 .theme-toggle:hover {
-    background-color: rgba(0,0,0,0.1);
+    background-color: #f5f5f5;
+    border: 1px solid var(--accent);
+}
+
+.dark-theme .theme-toggle {
+    background: #232526;
+    border: 1px solid #444;
 }
 
 .dark-theme .theme-toggle:hover {
-    background-color: rgba(255,255,255,0.1);
+    background-color: #181a1b;
+    border: 1px solid #ff5252;
 }
 
 /* Mobile menu */
@@ -216,70 +272,86 @@ footer {
     display: none;
     background: none;
     border: none;
-    font-size: 1.5rem;
+    font-size: 2rem;
     cursor: pointer;
     position: absolute;
-    top: 1rem;
-    left: 1rem;
+    top: 1.2rem;
+    left: 1.2rem;
+    color: var(--accent);
 }
 
 /* Search feature */
 .search-container {
     position: absolute;
-    top: 1rem;
+    top: 1.2rem;
     left: 50%;
     transform: translateX(-50%);
     display: flex;
     align-items: center;
+    background: #fff;
+    border-radius: 20px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.07);
+    padding: 0.2rem 0.7rem;
 }
 
 .search-input {
     padding: 0.5rem;
     border: none;
     border-radius: 20px;
-    width: 200px;
-    font-size: 0.9rem;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    width: 220px;
+    font-size: 1rem;
+    background: transparent;
+    outline: none;
 }
 
 .search-button {
     background: none;
     border: none;
-    font-size: 1.2rem;
+    font-size: 1.3rem;
     cursor: pointer;
     margin-left: 0.5rem;
+    color: var(--accent);
 }
 
 /* Newsletter signup */
 .newsletter-signup {
-    margin-top: 1.5rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid rgba(0,0,0,0.1);
+    margin-top: 2rem;
+    padding-top: 2rem;
+    border-top: 1px solid #ececec;
+    background: #fafbfc;
+    border-radius: var(--border-radius);
+    max-width: 500px;
+    margin-left: auto;
+    margin-right: auto;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.04);
 }
 
 .dark-theme .newsletter-signup {
-    border-top: 1px solid rgba(255,255,255,0.1);
+    border-top: 1px solid #333;
+    background: #232526;
 }
 
 .newsletter-signup h3 {
     margin-top: 0;
-    color: #333;
+    color: var(--accent);
+    font-family: var(--font-headline);
 }
 
 .dark-theme .newsletter-signup h3 {
-    color: #e0e0e0;
+    color: #ff5252;
 }
 
 .newsletter-signup form {
     display: flex;
-    margin: 1rem 0;
+    margin: 1.2rem 0;
 }
 
 .newsletter-signup input {
     flex: 1;
-    padding: 0.5rem;
+    padding: 0.6rem;
     border: 1px solid #ddd;
     border-radius: 4px 0 0 4px;
+    font-size: 1rem;
 }
 
 .dark-theme .newsletter-signup input {
@@ -289,22 +361,24 @@ footer {
 }
 
 .newsletter-signup button {
-    padding: 0.5rem 1rem;
-    background: #f57c00;
+    padding: 0.6rem 1.2rem;
+    background: var(--accent);
     color: white;
     border: none;
     border-radius: 0 4px 4px 0;
     cursor: pointer;
-    transition: background-color 0.3s;
+    font-weight: 700;
+    font-size: 1rem;
+    transition: background-color var(--transition);
 }
 
 .newsletter-signup button:hover {
-    background: #e65100;
+    background: var(--accent-dark);
 }
 
 .newsletter-message {
-    font-size: 0.9rem;
-    margin: 0.5rem 0;
+    font-size: 1rem;
+    margin: 0.7rem 0;
     height: 1.2em;
 }
 
@@ -313,7 +387,7 @@ footer {
 }
 
 .newsletter-message.error {
-    color: #f44336;
+    color: #c00;
 }
 
 .dark-theme .newsletter-message.success {
@@ -321,53 +395,51 @@ footer {
 }
 
 .dark-theme .newsletter-message.error {
-    color: #e57373;
+    color: #ff5252;
 }
 
 /* Responsive design */
+@media (max-width: 900px) {
+    main {
+        max-width: 100%;
+        padding: 0 0.5rem;
+    }
+}
 @media (max-width: 768px) {
     header h1 {
         font-size: 2rem;
     }
-    
     nav ul {
         flex-direction: column;
-        gap: 0.5rem;
+        gap: 0.7rem;
         max-height: 0;
         overflow: hidden;
-        transition: max-height 0.3s ease;
+        transition: max-height var(--transition);
     }
-    
     nav.mobile-open ul {
         max-height: 300px;
     }
-    
     .mobile-menu-toggle {
         display: block;
     }
-    
     .search-container {
         position: static;
         transform: none;
         margin: 1rem auto;
-        width: 90%;
-        max-width: 300px;
+        width: 95%;
+        max-width: 320px;
     }
-    
     .theme-toggle {
-        top: 1rem;
-        right: 1rem;
+        top: 1.2rem;
+        right: 1.2rem;
     }
-    
     .newsletter-signup form {
         flex-direction: column;
     }
-    
     .newsletter-signup input {
         border-radius: 4px;
         margin-bottom: 0.5rem;
     }
-    
     .newsletter-signup button {
         border-radius: 4px;
     }


### PR DESCRIPTION
The design of the news website in `may-2025/joyful-sunshine/news-website` has been significantly enhanced to match the visual appeal of premium news sites like CNN, BBC, and Geektime. Improvements include:

- Modernized layout with increased whitespace and clear content separation
- Upgraded typography using Roboto and Roboto Slab for a professional, readable look
- A bold, news-style color scheme (red accents, clean backgrounds, subtle shadows)
- Improved navigation and article styling for a more engaging, premium feel
- Responsive and accessible design maintained

All changes have been committed and pushed to the branch `may-2025/joyful-sunshine/news-website`.